### PR TITLE
✨ Feat: Add AlkaidFastConfigCenter.

### DIFF
--- a/alkaid-bukkit/src/main/java/com/alkaidmc/alkaid/bukkit/config/AlkaidJsonConfiguration.java
+++ b/alkaid-bukkit/src/main/java/com/alkaidmc/alkaid/bukkit/config/AlkaidJsonConfiguration.java
@@ -16,6 +16,7 @@
 
 package com.alkaidmc.alkaid.bukkit.config;
 
+import com.alkaidmc.alkaid.bukkit.config.gson.AlkaidFastConfigCenter;
 import com.google.gson.Gson;
 import org.bukkit.plugin.Plugin;
 
@@ -88,5 +89,30 @@ public class AlkaidJsonConfiguration {
             e.printStackTrace();
         }
         return null;
+    }
+
+    /**
+     * <p> zh </p>
+     * 快速读取配置文件， <br>
+     * 开发者无需维护json文件， <br>
+     * 只需要专注编写代码即可 <br>
+     * 加载成功后使用 Gson 转换成数据实体并返回 <br>
+     *
+     * <p> en </p>
+     * Quickly read the configuration file, <br>
+     * Developers don't need to maintain the JSON file, <br>
+     * Just focus on writing code, <br>
+     * After successful loading, convert it into a data entity using Gson and return it. <br>
+     *
+     * @param plugin        插件实例 / Plugin instance
+     * @param configName    配置文件名 / Config name
+     * @param defaultConfig 初始配置 / Resource path in plugin jar
+     * @return 依赖注入后的数据实体快照 / Dependency injection data entity snapshot
+     */
+    public <T> T fastLoad(Plugin plugin, String configName, T defaultConfig) {
+        String fileName = "./plugins/" + plugin.getName() + "/" + configName + ".json";
+        AlkaidFastConfigCenter afc = new AlkaidFastConfigCenter();
+        afc.makeDefaultConfig(fileName, defaultConfig);
+        return (T) afc.readSnapshot(fileName, defaultConfig.getClass());
     }
 }

--- a/alkaid-bukkit/src/main/java/com/alkaidmc/alkaid/bukkit/config/gson/AlkaidFastConfigCenter.java
+++ b/alkaid-bukkit/src/main/java/com/alkaidmc/alkaid/bukkit/config/gson/AlkaidFastConfigCenter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Alkaid
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.alkaidmc.alkaid.bukkit.config.gson;
 
 import com.google.gson.Gson;

--- a/alkaid-bukkit/src/main/java/com/alkaidmc/alkaid/bukkit/config/gson/AlkaidFastConfigCenter.java
+++ b/alkaid-bukkit/src/main/java/com/alkaidmc/alkaid/bukkit/config/gson/AlkaidFastConfigCenter.java
@@ -1,0 +1,110 @@
+package com.alkaidmc.alkaid.bukkit.config.gson;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.experimental.Accessors;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+public class AlkaidFastConfigCenter {
+    @Getter
+    @Accessors(fluent = true)
+    @SuppressWarnings("unused")
+    @RequiredArgsConstructor(staticName = "of")
+    public static class Pair<F, S> {
+        final F first;
+        final S second;
+    }
+
+    private final Gson gson = new GsonBuilder().setPrettyPrinting().create();
+    private final Map<String, Pair<File, JsonObject>> jsonFiles = new HashMap<>();
+
+    private JsonObject getConfigObject(String fileName) {
+        if (jsonFiles.containsKey(fileName)) {
+            return jsonFiles.get(fileName).second();
+        } else {
+            File configFile = getConfigFile(fileName);
+            JsonObject configObject;
+            if (configFile.isFile()) {
+                String jsonText = readFile(configFile);
+                configObject = gson.fromJson(jsonText, JsonObject.class);
+            } else {
+                configObject = new JsonObject();
+            }
+            jsonFiles.put(fileName, Pair.of(configFile, configObject));
+            return configObject;
+        }
+    }
+
+    public void makeDefaultConfig(String fileName, Object def) {
+        JsonObject defaultObject = gson.fromJson(gson.toJson(def), JsonObject.class);
+        JsonObject configObject = getConfigObject(fileName);
+
+        defaultObject.keySet().forEach(it -> {
+            if (!configObject.has(it)) {
+                configObject.add(it, defaultObject.get(it));
+            }
+        });
+        save(fileName);
+    }
+
+    public <T> T readSnapshot(String fileName, Class<T> type) {
+        return gson.fromJson(gson.toJson(getConfigObject(fileName)), type);
+    }
+
+    private File getConfigFile(String fileName) {
+        return new File(fileName);
+    }
+
+    public JsonElement getValue(String fileName, String key) {
+        var element = getConfigObject(fileName).get(key);
+        if (element == null) {
+            element = new JsonObject();
+        }
+        return element;
+    }
+
+    public void setValue(String fileName, String key, JsonElement value) {
+        getConfigObject(fileName).add(key, value);
+        save(fileName);
+    }
+
+    public void saveAll() {
+        jsonFiles.keySet().forEach(this::save);
+    }
+
+    private void save(String fileName) {
+        if (jsonFiles.containsKey(fileName)) {
+            File file = jsonFiles.get(fileName).first();
+            JsonObject obj = jsonFiles.get(fileName).second();
+            file.getParentFile().mkdirs();
+            saveFile(file, gson.toJson(obj));
+            System.out.println(obj);
+        } else {
+            System.out.println("保存失败：$fileName");
+        }
+    }
+
+    @SneakyThrows
+    private void saveFile(File file, String text) {
+        FileOutputStream fileOutputStream = new FileOutputStream(file);
+        fileOutputStream.write(text.getBytes(StandardCharsets.UTF_8));
+        fileOutputStream.close();
+    }
+
+    @SneakyThrows
+    private String readFile(File file) {
+        FileInputStream fileInputStream = new FileInputStream(file);
+        String text = new String(fileInputStream.readAllBytes(), StandardCharsets.UTF_8);
+        fileInputStream.close();
+        return text;
+    }
+}


### PR DESCRIPTION
Quickly read the configuration file, 
Developers don't need to maintain the JSON file,  
Just focus on writing code, 
After successful loading, convert it into a data entity using Gson and return it.