### PR TITLE
🐛 Fix: Prevent NullPointerException when creating directories.

### DIFF
--- a/alkaid-bukkit/src/main/java/com/alkaidmc/alkaid/bukkit/config/gson/AlkaidFastConfigCenter.java
+++ b/alkaid-bukkit/src/main/java/com/alkaidmc/alkaid/bukkit/config/gson/AlkaidFastConfigCenter.java
@@ -206,7 +206,7 @@ public class AlkaidFastConfigCenter {
         if (jsonFiles.containsKey(fileName)) {
             File file = jsonFiles.get(fileName).first();
             JsonObject obj = jsonFiles.get(fileName).second();
-            file.getParentFile().mkdirs();
+            if (file.getParentFile() != null) file.getParentFile().mkdirs();
             saveFile(file, gson.toJson(obj));
             System.out.println(obj);
         } else {


### PR DESCRIPTION
Ensure the parent directory is only created if the `getParentFile()` is not null, averting a potential `NullPointerException`. This adjustment safeguards the config handling against issues when the file object might not have a parent directory.